### PR TITLE
CWE-150447:

### DIFF
--- a/src/main/resources/lib/compuware/hostSelect.jelly
+++ b/src/main/resources/lib/compuware/hostSelect.jelly
@@ -10,7 +10,7 @@
 	
 	<div class="host-selection-control">
 		<f:select clazz="${attrs.clazz} host-select" field="${attrs.field}" value="${attrs.value}" default="${attrs.default}" />
-    	<a class="configure" href="/configure#cpwr-config">Manage connections</a>
+    	<a class="configure" href="${rootURL}/configure#cpwr-config">Manage connections</a>
     </div>
     
 </j:jelly>


### PR DESCRIPTION
The Taglib <cc:hostSelect> in Jenkins Compuare Commons Plugin will lead
to 404 if Jenkins is mounted in context path other than root