### PR TITLE
CWE-172865: created CpwrGlobalConfiguration.getUserLoginInformation()

### DIFF
--- a/src/main/java/com/compuware/jenkins/common/configuration/CpwrGlobalConfiguration.java
+++ b/src/main/java/com/compuware/jenkins/common/configuration/CpwrGlobalConfiguration.java
@@ -2,6 +2,8 @@
  * The MIT License (MIT)
  * 
  * Copyright (c) 2015 - 2019 Compuware Corporation
+ * (c) Copyright 2015 - 2019, 2021 BMC Software, Inc.
+ * 
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
@@ -30,6 +32,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.matchers.IdMatcher;
@@ -427,6 +430,32 @@ public class CpwrGlobalConfiguration extends GlobalConfiguration
 		{
 			if (matcher.matches(c))
 			{
+				credentials = c;
+			}
+		}
+
+		return credentials;
+	}
+	
+	/**
+	 * Retrieves login information given a credentials identifier.
+	 * 
+	 * @param project
+	 *            the Jenkins project
+	 * @param credentialsId
+	 *            the <code>String</code> identifier of the credentials to obtain
+	 * @return StandardCredentials object contains the credentials with login information
+	 * 			this object can be of type UsernamePasswordCredentialsImpl or CertificateCredentialsImpl.
+	 */
+	public StandardCredentials getUserLoginInformation(Item project, String credentialsId) {
+		StandardCredentials credentials = null;
+
+		List<StandardCredentials> credentialsList = CredentialsProvider.lookupCredentials(StandardCredentials.class,
+				project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList());
+
+		IdMatcher matcher = new IdMatcher(credentialsId);
+		for (StandardCredentials c : credentialsList) {
+			if (matcher.matches(c)) {
 				credentials = c;
 			}
 		}


### PR DESCRIPTION
method that return StandardCredentials object contains the credentials
with login information this object can be of type
UsernamePasswordCredentialsImpl or CertificateCredentialsImpl.

Added configure_system_credentials() to HostConnectionTest to test
retrieves login information given a credentials identifier.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
