### PR TITLE
ZENG-229811: Fix corruption of certificate parameter.

### DIFF
--- a/src/main/java/com/compuware/jenkins/common/configuration/CpwrGlobalConfiguration.java
+++ b/src/main/java/com/compuware/jenkins/common/configuration/CpwrGlobalConfiguration.java
@@ -640,7 +640,7 @@ public class CpwrGlobalConfiguration extends GlobalConfiguration
 		// Don't add userid for now.  This comes out as a long string and causes problems with the CLI argument parser.
 		try {
 			// 2021-06-01 Escaped cert fails. so pass it as is.
-			String certificateStr = getCertificateString(credentials);
+			String certificateStr = ArgumentUtils.wrapInDoubleQuotes(getCertificateString(credentials));
 			if (certificateStr != null) {
 				args.add(CommonConstants.CERT_PARM);
 				args.add(certificateStr, true);


### PR DESCRIPTION
We need to wrap certificate value in double quotes to prevent the loss of parameter separating characters (such as "=").

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
